### PR TITLE
feat: add GitHub wrapper to submit pull requests

### DIFF
--- a/.config.example.json
+++ b/.config.example.json
@@ -1,4 +1,7 @@
 {
+  "github": {
+    "token": "token_created_from_github_com"
+  },
   "telegram": {
     "onlyfromuserid": "299893686"
   },

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -282,6 +282,98 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@octokit/endpoint": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
+      "integrity": "sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==",
+      "requires": {
+        "@octokit/types": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        }
+      }
+    },
+    "@octokit/request": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
+      "integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
+      "requires": {
+        "@octokit/endpoint": "^5.5.0",
+        "@octokit/request-error": "^1.0.1",
+        "@octokit/types": "^2.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.0.tgz",
+      "integrity": "sha512-DNBhROBYjjV/I9n7A8kVkmQNkqFAMem90dSxqvPq57e2hBr7mNTX98y3R2zDpqMQHVRpBDjsvsfIGgBzy+4PAg==",
+      "requires": {
+        "@octokit/types": "^2.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.36.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.36.0.tgz",
+      "integrity": "sha512-zoZj7Ya4vWBK4fjTwK2Cnmu7XBB1p9ygSvTk2TthN6DVJXM4hQZQoAiknWFLJWSTix4dnA3vuHtjPZbExYoCZA==",
+      "requires": {
+        "@octokit/request": "^5.2.0",
+        "@octokit/request-error": "^1.0.2",
+        "atob-lite": "^2.0.0",
+        "before-after-hook": "^2.0.0",
+        "btoa-lite": "^1.0.0",
+        "deprecation": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^4.0.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.0.2.tgz",
+      "integrity": "sha512-StASIL2lgT3TRjxv17z9pAqbnI7HGu9DrJlg3sEBFfCLaMEqp+O3IQPUF6EZtQ4xkAu2ml6kMBBCtGxjvmtmuQ==",
+      "requires": {
+        "@types/node": ">= 8"
+      }
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -928,6 +1020,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -1026,6 +1123,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
     },
     "big-integer": {
       "version": "1.6.48",
@@ -1215,6 +1317,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bson-objectid/-/bson-objectid-1.3.0.tgz",
       "integrity": "sha512-YcB+lRJEEEIcHNLKyhmHujW7OCVE3+xr9IpEhlprBZnXgF3hqeePeexIsAaOtu1SbkgZRlJVUxvYZ3ngUOyIew=="
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "buffer": {
       "version": "5.4.3",
@@ -1909,7 +2016,6 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -1921,8 +2027,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -2145,6 +2250,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "destroy": {
       "version": "1.0.4",
@@ -4513,8 +4623,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -4887,6 +4996,11 @@
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.has": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
@@ -4959,6 +5073,11 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
     "lodash.snakecase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
@@ -4982,6 +5101,11 @@
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
       "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "lodash.values": {
       "version": "2.4.1",
@@ -5028,6 +5152,11 @@
       "requires": {
         "es5-ext": "~0.10.2"
       }
+    },
+    "macos-release": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
+      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
     },
     "make-dir": {
       "version": "3.0.0",
@@ -5392,8 +5521,7 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nock": {
       "version": "11.7.0",
@@ -5473,7 +5601,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -5573,6 +5700,11 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -5683,6 +5815,15 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
+    "os-name": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+      "requires": {
+        "macos-release": "^2.2.0",
+        "windows-release": "^3.1.0"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -5708,8 +5849,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "2.2.1",
@@ -5794,8 +5934,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -6525,7 +6664,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -6533,8 +6671,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "side-channel": {
       "version": "1.0.2",
@@ -6926,8 +7063,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
       "version": "3.0.1",
@@ -7654,6 +7790,14 @@
         }
       }
     },
+    "universal-user-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
+      "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
+      "requires": {
+        "os-name": "^3.1.0"
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -7967,7 +8111,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -8084,6 +8227,43 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
+        }
+      }
+    },
+    "windows-release": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+      "requires": {
+        "execa": "^1.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         }
       }
     },

--- a/functions/package.json
+++ b/functions/package.json
@@ -19,6 +19,7 @@
     "webhook:bind": "source ../.env && curl https://api.telegram.org/bot${BOT_TOKEN}/setWebhook?url=${ROUTER_URL}",
     "webhook:test": "source ../.env && curl https://api.telegram.org/bot${BOT_TOKEN}/getWebhookInfo",
     "logs": "firebase functions:log",
+    "github:test": "ts-node tools/github-branches.ts",
     "ticktick:test": "ts-node tools/ticktick.ts",
     "trello:test": "source ../.env && curl -LI \"https://api.trello.com/1/members/me/boards?key=${TRELLO_API_KEY}&token=${TRELLO_USER_TOKEN}\" -s | grep HTTP",
     "trello:checklist": "ts-node tools/trello-checklist.ts",
@@ -31,6 +32,7 @@
   "author": "Adrien Joly",
   "license": "ISC",
   "dependencies": {
+    "@octokit/rest": "^16.36.0",
     "@types/cors": "^2.8.6",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/functions/src/GitHub.ts
+++ b/functions/src/GitHub.ts
@@ -1,0 +1,112 @@
+import assert from 'assert'
+import Octokit from '@octokit/rest' // API Ref Doc: https://octokit.github.io/rest.js/
+
+export class GitHub {
+  octokit: Octokit
+
+  constructor(octokit: Octokit) {
+    this.octokit = octokit
+  }
+
+  async getFileContents({
+    owner,
+    repo,
+    path,
+  }: {
+    owner: string
+    repo: string
+    path: string
+  }): Promise<{ sha: string; buffer: Buffer }> {
+    const res = await this.octokit.repos.getContents({
+      owner,
+      repo,
+      path,
+    })
+    const data = res.data as Octokit.ReposGetContentsResponseItem & {
+      encoding: string
+      content: string
+    }
+    assert.equal(data.encoding, 'base64')
+    return {
+      sha: data.sha,
+      buffer: Buffer.from(data.content, 'base64'),
+    }
+  }
+
+  async proposeFileChangePR({
+    owner,
+    repo,
+    filePath,
+    contentToAdd,
+    branchName,
+    prTitle,
+    prBody,
+    log = () => {},
+  }: {
+    owner: string
+    repo: string
+    filePath: string
+    contentToAdd: string
+    branchName: string
+    prTitle: string
+    prBody: string
+    log?: (s: string) => void
+  }): Promise<Octokit.PullsCreateResponse> {
+    const octokit = this.octokit
+    log(`Fetch last commit from ${owner}/${repo}...`)
+    const lastCommit = await (await octokit.repos.listCommits({ owner, repo }))
+      .data[0]
+    log(`Fetch contents of ${filePath}...`)
+    const initialFile = await getFileContents({
+      owner,
+      repo,
+      path: filePath,
+    })
+    log(`Create blob with changed file contents...`)
+    const { data: blob } = await octokit.git.createBlob({
+      owner,
+      repo,
+      content: initialFile.buffer.toString() + contentToAdd,
+      encoding: 'utf-8',
+    })
+    log(`Create tree with changed file contents...`)
+    const { data: tree } = await octokit.git.createTree({
+      owner,
+      repo,
+      base_tree: lastCommit.commit.tree.sha,
+      tree: [
+        {
+          type: 'blob',
+          mode: '100644',
+          path: filePath,
+          sha: blob.sha,
+        },
+      ],
+    })
+    log(`Create commit...`)
+    const { data: newCommit } = await octokit.git.createCommit({
+      owner,
+      repo,
+      message: `add test content to ${filePath}`,
+      tree: tree.sha,
+      parents: [lastCommit.sha],
+    })
+    log(`Create branch: ${branchName}...`)
+    await octokit.git.createRef({
+      owner,
+      repo,
+      ref: `refs/heads/${branchName}`,
+      sha: newCommit.sha,
+    })
+    log(`Create pull request: ${prTitle}...`)
+    const { data } = await octokit.pulls.create({
+      owner,
+      repo,
+      title: prTitle,
+      head: branchName,
+      base: 'master',
+      body: prBody,
+    })
+    return data
+  }
+}

--- a/functions/src/GitHub.ts
+++ b/functions/src/GitHub.ts
@@ -1,11 +1,23 @@
 import assert from 'assert'
 import Octokit from '@octokit/rest' // API Ref Doc: https://octokit.github.io/rest.js/
 
+const USER_AGENT = 'telegram-scribe-bot'
+
 export class GitHub {
   octokit: Octokit
 
-  constructor(octokit: Octokit) {
-    this.octokit = octokit
+  constructor({
+    token,
+    userAgent = USER_AGENT,
+  }: {
+    token: string
+    userAgent?: string
+  }) {
+    this.octokit = new Octokit({
+      auth: token,
+      userAgent,
+      // log: console, // uncomment this line to trace debug info
+    })
   }
 
   async getFileContents({
@@ -57,7 +69,7 @@ export class GitHub {
     const lastCommit = await (await octokit.repos.listCommits({ owner, repo }))
       .data[0]
     log(`Fetch contents of ${filePath}...`)
-    const initialFile = await getFileContents({
+    const initialFile = await this.getFileContents({
       owner,
       repo,
       path: filePath,

--- a/functions/tools/github-branches.ts
+++ b/functions/tools/github-branches.ts
@@ -9,16 +9,28 @@ const octokit = new Octokit({
   // log: console, // uncomment this line to trace debug info
 })
 
-octokit.repos
-  .listBranches({ owner: 'adrienjoly', repo: 'album-shelf' })
-  .then(({ data, status }) => {
-    if (status !== 200) {
-      console.error({ data, status })
-    } else {
-      console.log({ data, status })
-    }
-  })
-  .catch(err => {
-    console.error(err)
-    process.exit(1)
-  })
+const { owner, repo } = { owner: 'adrienjoly', repo: 'album-shelf' }
+
+async function getLastCommit() {
+  const { data, status } = await octokit.repos
+    //.listBranches()
+    .listCommits({
+      owner,
+      repo,
+    })
+  if (status !== 200) {
+    throw new Error(`GitHub API -> ${status}: ${data.toString()}`)
+  } else {
+    return data[0]
+  }
+}
+
+async function main() {
+  const { sha, commit } = await getLastCommit()
+  console.log(`last commit: (${sha}) ${commit.message}`)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/functions/tools/github-branches.ts
+++ b/functions/tools/github-branches.ts
@@ -1,0 +1,19 @@
+import Octokit from '@octokit/rest'
+
+// load credentials from config file
+// const { github } = require(`${__dirname}/../../.config.json`) // eslint-disable-line @typescript-eslint/no-var-requires
+
+const octokit = new Octokit({
+  userAgent: 'telegram-scribe-bot',
+  log: console,
+})
+
+octokit.repos
+  .listBranches({ owner: 'adrienjoly', repo: 'album-shelf' })
+  .then(({ data, headers, status }) => {
+    console.log({ data, headers, status })
+  })
+  .catch(err => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/functions/tools/github-branches.ts
+++ b/functions/tools/github-branches.ts
@@ -98,8 +98,19 @@ async function main() {
     repo,
     path: '_data/albums.yaml',
   })
-  console.log('=> data:', buffer.toString())
-  console.log('=>', { sha })
+  console.log('getFileContents => data:', buffer.toString())
+  console.log('getFileContents =>', { sha })
+
+  const content = buffer.toString() + 'test'
+
+  const { data: blob } = await octokit.git.createBlob({
+    owner,
+    repo,
+    content,
+    encoding: 'utf-8',
+  })
+
+  console.log('createBlob =>', blob.sha)
 }
 
 main().catch(err => {

--- a/functions/tools/github-branches.ts
+++ b/functions/tools/github-branches.ts
@@ -1,133 +1,31 @@
 import Octokit from '@octokit/rest' // API Ref Doc: https://octokit.github.io/rest.js/
-import assert from 'assert'
+import { GitHub } from '../src/GitHub'
 
 // Load credentials from config file
-const { github } = require(`${__dirname}/../../.config.json`) // eslint-disable-line @typescript-eslint/no-var-requires
+const { TOKEN } = require(`${__dirname}/../../.config.json`).github // eslint-disable-line @typescript-eslint/no-var-requires
 // Note: In order to write to the repo, user must be authenticated with a token
 // that has the "public_repo" permission.
 
-const octokit = new Octokit({
-  auth: github.token,
-  userAgent: 'telegram-scribe-bot',
-  // log: console, // uncomment this line to trace debug info
-})
+const USER_AGENT = 'telegram-scribe-bot'
 
-async function getFileContents({
-  owner,
-  repo,
-  path,
-}: {
-  owner: string
-  repo: string
-  path: string
-}): Promise<{ sha: string; buffer: Buffer }> {
-  const res = await octokit.repos.getContents({
-    owner,
-    repo,
-    path,
-  })
-  const data = res.data as Octokit.ReposGetContentsResponseItem & {
-    encoding: string
-    content: string
-  }
-  assert.equal(data.encoding, 'base64')
-  return {
-    sha: data.sha,
-    buffer: Buffer.from(data.content, 'base64'),
-  }
-}
-
-async function proposeFileChangePR({
-  owner,
-  repo,
-  filePath,
-  contentToAdd,
-  branchName,
-  prTitle,
-  prBody,
-  log = () => {},
-}: {
-  owner: string
-  repo: string
-  filePath: string
-  contentToAdd: string
-  branchName: string
-  prTitle: string
-  prBody: string
-  log?: (s: string) => void
-}): Promise<Octokit.PullsCreateResponse> {
-  log(`Fetch last commit from ${owner}/${repo}...`)
-  const lastCommit = await (await octokit.repos.listCommits({ owner, repo }))
-    .data[0]
-
-  log(`Fetch contents of ${filePath}...`)
-  const initialFile = await getFileContents({
-    owner,
-    repo,
-    path: filePath,
-  })
-
-  log(`Create blob with changed file contents...`)
-  const { data: blob } = await octokit.git.createBlob({
-    owner,
-    repo,
-    content: initialFile.buffer.toString() + contentToAdd,
-    encoding: 'utf-8',
-  })
-
-  log(`Create tree with changed file contents...`)
-  const { data: tree } = await octokit.git.createTree({
-    owner,
-    repo,
-    base_tree: lastCommit.commit.tree.sha,
-    tree: [
-      {
-        type: 'blob',
-        mode: '100644',
-        path: filePath,
-        sha: blob.sha,
-      },
-    ],
-  })
-
-  log(`Create commit...`)
-  const { data: newCommit } = await octokit.git.createCommit({
-    owner,
-    repo,
-    message: `add test content to ${filePath}`,
-    tree: tree.sha,
-    parents: [lastCommit.sha],
-  })
-
-  log(`Create branch: ${branchName}...`)
-  await octokit.git.createRef({
-    owner,
-    repo,
-    ref: `refs/heads/${branchName}`,
-    sha: newCommit.sha,
-  })
-
-  log(`Create pull request: ${prTitle}...`)
-  const { data } = await octokit.pulls.create({
-    owner,
-    repo,
-    title: prTitle,
-    head: branchName,
-    base: 'master',
-    body: prBody,
-  })
-  return data
+const PULL_REQUEST_DATA = {
+  owner: 'adrienjoly',
+  repo: 'album-shelf',
+  filePath: '_data/albums.yaml',
+  contentToAdd: '\ntest\n',
 }
 
 async function main() {
-  const filePath = '_data/albums.yaml'
-  const pr = await proposeFileChangePR({
-    owner: 'adrienjoly',
-    repo: 'album-shelf',
-    filePath,
-    contentToAdd: '\ntest\n',
+  const octokit = new Octokit({
+    auth: TOKEN,
+    userAgent: USER_AGENT,
+    // log: console, // uncomment this line to trace debug info
+  })
+  const github = new GitHub(octokit)
+  const pr = await github.proposeFileChangePR({
+    ...PULL_REQUEST_DATA,
     branchName: `scribe-bot-${Date.now()}`,
-    prTitle: `add test to ${filePath}`,
+    prTitle: `add test to ${PULL_REQUEST_DATA.filePath}`,
     prBody: 'Submitted by `telegram-scribe-bot`',
     log: console.warn,
   })

--- a/functions/tools/github-branches.ts
+++ b/functions/tools/github-branches.ts
@@ -22,19 +22,19 @@ async function getLastCommit(ghRepo: GitHubRepo) {
 async function createBranch({
   owner,
   repo,
-  name = `scribe-bot-test`,
+  name,
 }: GitHubRepo & {
   name?: string
 }) {
-  const { sha, commit } = await getLastCommit({ owner, repo })
-  console.log(`last commit: (${sha}) ${commit.message}`)
-  const { data } = await octokit.git.createRef({
-    owner,
-    repo,
-    ref: `refs/heads/${name}`,
-    sha,
-  })
-  return data
+  const { sha } = await getLastCommit({ owner, repo })
+  return (
+    await octokit.git.createRef({
+      owner,
+      repo,
+      ref: `refs/heads/${name}`,
+      sha,
+    })
+  ).data
 }
 
 async function main() {
@@ -42,7 +42,7 @@ async function main() {
     ref,
     node_id,
     object: { sha },
-  } = await createBranch({ owner, repo })
+  } = await createBranch({ owner, repo, name: `scribe-bot-test` })
   console.log('=>', { ref, node_id, sha })
 }
 

--- a/functions/tools/github-branches.ts
+++ b/functions/tools/github-branches.ts
@@ -1,7 +1,11 @@
 import Octokit from '@octokit/rest'
 
-// load credentials from config file
+// Load credentials from config file
 const { github } = require(`${__dirname}/../../.config.json`) // eslint-disable-line @typescript-eslint/no-var-requires
+// Note: In order to write to the repo, user must be authenticated with a token
+// that has the "public_repo" permission.
+
+type GitHubRepo = { owner: string; repo: string }
 
 const octokit = new Octokit({
   auth: github.token,
@@ -9,38 +13,43 @@ const octokit = new Octokit({
   // log: console, // uncomment this line to trace debug info
 })
 
-const { owner, repo } = { owner: 'adrienjoly2', repo: 'album-shelf' }
+const { owner, repo } = { owner: 'adrienjoly', repo: 'album-shelf' }
 
-async function getLastCommit({ owner, repo }: { owner: string; repo: string }) {
-  const { data } = await octokit.repos
-    //.listBranches()
-    .listCommits({
-      owner,
-      repo,
-    })
-  return data[0]
+async function getLastCommit(ghRepo: GitHubRepo) {
+  return (await octokit.repos.listCommits(ghRepo)).data[0]
 }
 
-async function createBranch({ owner, repo }: { owner: string; repo: string }) {
+async function createBranch({
+  owner,
+  repo,
+  name = `scribe-bot-test`,
+}: GitHubRepo & {
+  name?: string
+}) {
   const { sha, commit } = await getLastCommit({ owner, repo })
   console.log(`last commit: (${sha}) ${commit.message}`)
   const { data } = await octokit.git.createRef({
     owner,
     repo,
-    ref: 'refs/heads/invalid branch name XXX',
+    ref: `refs/heads/${name}`,
     sha,
   })
   return data
 }
 
 async function main() {
-  const data = await createBranch({ owner, repo })
-  console.log('=>', data)
+  const {
+    ref,
+    node_id,
+    object: { sha },
+  } = await createBranch({ owner, repo })
+  console.log('=>', { ref, node_id, sha })
 }
 
 main().catch(err => {
   console.error(
     `❌  ${err.message} <-- ${err.request?.url}\n   ${err.request?.body}`
   )
+  console.error(err.stack)
   process.exit(1)
 })

--- a/functions/tools/github-branches.ts
+++ b/functions/tools/github-branches.ts
@@ -9,28 +9,38 @@ const octokit = new Octokit({
   // log: console, // uncomment this line to trace debug info
 })
 
-const { owner, repo } = { owner: 'adrienjoly', repo: 'album-shelf' }
+const { owner, repo } = { owner: 'adrienjoly2', repo: 'album-shelf' }
 
-async function getLastCommit() {
-  const { data, status } = await octokit.repos
+async function getLastCommit({ owner, repo }: { owner: string; repo: string }) {
+  const { data } = await octokit.repos
     //.listBranches()
     .listCommits({
       owner,
       repo,
     })
-  if (status !== 200) {
-    throw new Error(`GitHub API -> ${status}: ${data.toString()}`)
-  } else {
-    return data[0]
-  }
+  return data[0]
+}
+
+async function createBranch({ owner, repo }: { owner: string; repo: string }) {
+  const { sha, commit } = await getLastCommit({ owner, repo })
+  console.log(`last commit: (${sha}) ${commit.message}`)
+  const { data } = await octokit.git.createRef({
+    owner,
+    repo,
+    ref: 'refs/heads/invalid branch name XXX',
+    sha,
+  })
+  return data
 }
 
 async function main() {
-  const { sha, commit } = await getLastCommit()
-  console.log(`last commit: (${sha}) ${commit.message}`)
+  const data = await createBranch({ owner, repo })
+  console.log('=>', data)
 }
 
 main().catch(err => {
-  console.error(err)
+  console.error(
+    `❌  ${err.message} <-- ${err.request?.url}\n   ${err.request?.body}`
+  )
   process.exit(1)
 })

--- a/functions/tools/github-branches.ts
+++ b/functions/tools/github-branches.ts
@@ -1,4 +1,4 @@
-import Octokit from '@octokit/rest'
+import Octokit from '@octokit/rest' // API Ref Doc: https://octokit.github.io/rest.js/
 import assert from 'assert'
 
 // Load credentials from config file
@@ -41,7 +41,9 @@ async function main() {
   const { owner, repo } = { owner: 'adrienjoly', repo: 'album-shelf' }
   const filePath = '_data/albums.yaml'
   const contentToAdd = '\ntest\n'
-  const branchName = `scribe-bot-test`
+  const branchName = `scribe-bot-${Date.now()}`
+  const prTitle = `add test to ${filePath}`
+  const prBody = 'Submitted by `telegram-scribe-bot`'
 
   console.log(`___\nFetch last commit from ${owner}/${repo}...`)
   const lastCommit = await (await octokit.repos.listCommits({ owner, repo }))
@@ -92,6 +94,16 @@ async function main() {
     repo,
     ref: `refs/heads/${branchName}`,
     sha: newCommit.sha,
+  })
+
+  console.log(`___\nCreate pull request: ${prTitle}...`)
+  await octokit.pulls.create({
+    owner,
+    repo,
+    title: prTitle,
+    head: branchName,
+    base: 'master',
+    body: prBody,
   })
 }
 

--- a/functions/tools/github-branches.ts
+++ b/functions/tools/github-branches.ts
@@ -99,34 +99,30 @@ async function main() {
   })
   console.log('createTree =>', { tree })
 
-  return
-
-  const branchName = `scribe-bot-test`
-  console.log(`___\nCreate branch: ${branchName}...`)
-  const {
-    data: {
-      ref,
-      node_id,
-      object: { sha: branchSha },
-    },
-  } = await octokit.git.createRef({
-    owner,
-    repo,
-    ref: `refs/heads/${branchName}`,
-    sha: lastCommit.sha,
-  })
-
-  console.log('createBranch =>', { ref, node_id, branchSha })
-
   console.log(`___\nCreate commit...`)
-  const { data } = await octokit.git.createCommit({
+  const { data: newCommit } = await octokit.git.createCommit({
     owner,
     repo,
     message: `add test content to ${filePath}`,
-    tree: branchSha,
-    parents: [initialFile.sha, blob.sha],
+    tree: tree.sha,
+    parents: [lastCommit.sha],
   })
-  console.log('createCommit =>', data)
+  console.log('createCommit =>', { commit: newCommit })
+
+  const branchName = `scribe-bot-test`
+  console.log(`___\nCreate branch: ${branchName}...`)
+  const { data: branchRef } = await octokit.git.createRef({
+    owner,
+    repo,
+    ref: `refs/heads/${branchName}`,
+    sha: newCommit.sha,
+  })
+  const {
+    ref,
+    node_id,
+    object: { sha: branchSha },
+  } = branchRef
+  console.log('createBranch =>', { ref, node_id, branchSha })
 }
 
 main().catch(err => {

--- a/functions/tools/github-branches.ts
+++ b/functions/tools/github-branches.ts
@@ -1,12 +1,9 @@
-import Octokit from '@octokit/rest' // API Ref Doc: https://octokit.github.io/rest.js/
 import { GitHub } from '../src/GitHub'
 
 // Load credentials from config file
-const { TOKEN } = require(`${__dirname}/../../.config.json`).github // eslint-disable-line @typescript-eslint/no-var-requires
+const { token } = require(`${__dirname}/../../.config.json`).github // eslint-disable-line @typescript-eslint/no-var-requires
 // Note: In order to write to the repo, user must be authenticated with a token
 // that has the "public_repo" permission.
-
-const USER_AGENT = 'telegram-scribe-bot'
 
 const PULL_REQUEST_DATA = {
   owner: 'adrienjoly',
@@ -16,12 +13,7 @@ const PULL_REQUEST_DATA = {
 }
 
 async function main() {
-  const octokit = new Octokit({
-    auth: TOKEN,
-    userAgent: USER_AGENT,
-    // log: console, // uncomment this line to trace debug info
-  })
-  const github = new GitHub(octokit)
+  const github = new GitHub({ token })
   const pr = await github.proposeFileChangePR({
     ...PULL_REQUEST_DATA,
     branchName: `scribe-bot-${Date.now()}`,

--- a/functions/tools/github-branches.ts
+++ b/functions/tools/github-branches.ts
@@ -1,17 +1,22 @@
 import Octokit from '@octokit/rest'
 
 // load credentials from config file
-// const { github } = require(`${__dirname}/../../.config.json`) // eslint-disable-line @typescript-eslint/no-var-requires
+const { github } = require(`${__dirname}/../../.config.json`) // eslint-disable-line @typescript-eslint/no-var-requires
 
 const octokit = new Octokit({
+  auth: github.token,
   userAgent: 'telegram-scribe-bot',
-  log: console,
+  // log: console, // uncomment this line to trace debug info
 })
 
 octokit.repos
   .listBranches({ owner: 'adrienjoly', repo: 'album-shelf' })
-  .then(({ data, headers, status }) => {
-    console.log({ data, headers, status })
+  .then(({ data, status }) => {
+    if (status !== 200) {
+      console.error({ data, status })
+    } else {
+      console.log({ data, status })
+    }
   })
   .catch(err => {
     console.error(err)

--- a/functions/tools/github-branches.ts
+++ b/functions/tools/github-branches.ts
@@ -1,11 +1,12 @@
 import Octokit from '@octokit/rest'
+import assert from 'assert'
 
 // Load credentials from config file
 const { github } = require(`${__dirname}/../../.config.json`) // eslint-disable-line @typescript-eslint/no-var-requires
 // Note: In order to write to the repo, user must be authenticated with a token
 // that has the "public_repo" permission.
 
-type GitHubRepo = { owner: string; repo: string }
+// type GitHubRepo = { owner: string; repo: string }
 
 const octokit = new Octokit({
   auth: github.token,
@@ -14,6 +15,7 @@ const octokit = new Octokit({
 })
 
 const { owner, repo } = { owner: 'adrienjoly', repo: 'album-shelf' }
+/*
 
 async function getLastCommit(ghRepo: GitHubRepo) {
   return (await octokit.repos.listCommits(ghRepo)).data[0]
@@ -24,7 +26,7 @@ async function createBranch({
   repo,
   name,
 }: GitHubRepo & {
-  name?: string
+  name: string
 }) {
   const { sha } = await getLastCommit({ owner, repo })
   return (
@@ -37,13 +39,53 @@ async function createBranch({
   ).data
 }
 
+async function createCommit({
+  owner,
+  repo,
+  name,
+  message,
+  tree,
+  parents
+}: GitHubRepo & {
+  name?: string
+  message:string
+  tree:
+  parents:
+}) { 
+  octokit.git.createCommit({
+    owner,
+    repo,
+    message,
+    tree,
+    parents
+  })
+}
+*/
+
 async function main() {
+  /*
   const {
     ref,
     node_id,
     object: { sha },
   } = await createBranch({ owner, repo, name: `scribe-bot-test` })
   console.log('=>', { ref, node_id, sha })
+  */
+
+  type ExtendedContent = Octokit.ReposGetContentsResponseItem & {
+    encoding: string
+    content: string
+  }
+  const res = await octokit.repos.getContents({
+    owner,
+    repo,
+    path: '_data/albums.yaml',
+  })
+  const data = res.data as ExtendedContent
+  assert.equal(data.encoding, 'base64')
+  const fileContent = Buffer.from(data.content, 'base64').toString()
+  console.log('=> data:', fileContent)
+  console.log('=>', { sha: data.sha })
 }
 
 main().catch(err => {


### PR DESCRIPTION
`npm run github:test` submits a Pull Request that adds content to a file from https://github.com/adrienjoly/album-shelf.

E.g. https://github.com/adrienjoly/album-shelf/pull/10

The underlying GitHub wrapper is ready to be used from the bot.