### PR TITLE
fix(ci): "EADDRINUSE: address already in use :::8084" error

### DIFF
--- a/functions/src/app.test.ts
+++ b/functions/src/app.test.ts
@@ -7,7 +7,7 @@ import { startApp } from './app'
 const options = {}
 
 const allocatePort = (() => {
-  let current = 8081
+  let current = 8091
   return () => current++
 })()
 


### PR DESCRIPTION
See https://github.com/adrienjoly/telegram-scribe-bot/runs/2574151959#step:7:54.

```
  npm test
  shell: /usr/bin/bash -e {0}

> telegram-scribe-bot@1.6.1 test /home/runner/work/telegram-scribe-bot/telegram-scribe-bot/functions
> ts-mocha -p ./tsconfig.json './**/*.test.ts'



  app
    ✓ responds to GET / (56ms)
    ✓ responds 400 to invalid telegram message
    ✓ responds to valid telegram message
    1) warns in case of telegram message from unauthorized user
    ✓ responds with error if failing to connect to trello

  spotify use cases
    parseAlbumId
      ✓ detects album id from URL
    addSpotifyAlbumToShelfRepo
      ✓ fails if no albumId was found in the message
      ✓ extracts the albumId and generates a pull request (50ms)

  trello use cases
    (shared behaviors)
      ✓ fails if trello credentials are not provided
      ✓ fails if trello credentials are empty
      ✓ suggests existing tags if no tags were provided
      ✓ suggests existing tags if no card matches the tag
      ✓ tolerates cards that are not associated with a tag
      ✓ invites to bind tags to card, if none were found
    listTags
      ✓ should list tags associated with each Trello card
    addAsTrelloComment
      ✓ succeeds
      ✓ succeeds if tag is specified without hash, in the card
    addAsTrelloTask
      ✓ fails if matching card has no checklist
      ✓ should add the task to the checklist of a card
      ✓ should add the task to the top checklist of a card
    getNextTrelloTasks
      ✓ returns the first incomplete task of the only card of a board
      ✓ returns the first tasks of both cards of a board
      ✓ skips cards that don't have a checklist
      ✓ skips cards that don't have a hashtag


  23 passing (264ms)
  1 failing

  1) app
       warns in case of telegram message from unauthorized user:
     Uncaught Error: listen EADDRINUSE: address already in use :::8084
      at Server.setupListenHandle [as _listen2] (net.js:1316:16)
      at listenInCluster (net.js:1364:12)
      at Server.listen (net.js:1450:7)
      at Function.listen (node_modules/express/lib/application.js:618:24)
      at /home/runner/work/telegram-scribe-bot/telegram-scribe-bot/functions/src/app.ts:67:39
      at new Promise (<anonymous>)
      at Object.startApp (src/app.ts:65:3)
      at Context.<anonymous> (src/app.test.ts:68:26)
      at processImmediate (internal/timers.js:461:21)



npm ERR! Test failed.  See above for more details.
```